### PR TITLE
replaced the OpenAiDictionary field with the general Dictionary interface type

### DIFF
--- a/src/main/java/langcontrol/app/flashcard/FlashcardServiceImpl.java
+++ b/src/main/java/langcontrol/app/flashcard/FlashcardServiceImpl.java
@@ -8,7 +8,7 @@ import langcontrol.app.exception.GeneralNotFoundException;
 import langcontrol.app.flashcard.rest.FlashcardForecastsDTO;
 import langcontrol.app.flashcard.rest.LearnModeForecastsDTO;
 import langcontrol.app.flashcard.rest.ReviewModeForecastsDTO;
-import langcontrol.app.generator.openai.OpenAiDictionary;
+import langcontrol.app.generator.Dictionary;
 import langcontrol.app.util.PrincipalRetriever;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -29,11 +29,11 @@ public class FlashcardServiceImpl implements FlashcardService {
 
     private final FlashcardRepository flashcardRepository;
     private final DeckRepository deckRepository;
-    private final OpenAiDictionary dictionary;
+    private final Dictionary dictionary;
 
     @Autowired
     public FlashcardServiceImpl(FlashcardRepository flashcardRepository, DeckRepository deckRepository,
-                                @Qualifier("openAiDictionary") OpenAiDictionary dictionary) {
+                                @Qualifier("openAiDictionary") Dictionary dictionary) {
         this.flashcardRepository = flashcardRepository;
         this.deckRepository = deckRepository;
         this.dictionary = dictionary;


### PR DESCRIPTION
I've changed the type of the 'dictionary' field in the FlashcardServiceImpl class from OpenAiDictionary to its interface Dictionary. It's considered a good practice to reference variables through interfaces rather than their implementations just in case there's a need to change that implementation. This way we can avoid affecting other classes where such a variable is used.